### PR TITLE
Update AutoNotify.cs

### DIFF
--- a/src/AutoNotify/AutoNotify.cs
+++ b/src/AutoNotify/AutoNotify.cs
@@ -26,12 +26,17 @@ namespace SourceGenerators
         public AutoNotifyAttribute()
         {
         }
-        public string PropertyName { get; set; }
+        public string PropertyName { get; set; } = ""; //Avoids Compliler Warning as this is set
         public Visibility GetterVisibility { get; set; } = Visibility.Public;
         public Visibility SetterVisibility { get; set; } = Visibility.Public;
         public EqualityCheck CheckEquality { get; set; } = EqualityCheck.None;
     }
-
+    
+    public AutoNotifyAttribute(string propertyName)
+    {
+        PropertyName = propertyName;
+    }
+    
     enum EqualityCheck {
         None = 0,
         Equals = 1,


### PR DESCRIPTION
Getting a lot of warnings in Framework:

Non-nullable property 'PropertyName' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.

This allows for it to be blank to avoid the error or allows the dev to set the PropertyName in the Attribute. I know you do not like allowing to be null:

public string? PropertyName { get; set; }